### PR TITLE
unit test and fixes for  LorentzianSqr + fixes for Lorentzian

### DIFF
--- a/uk.ac.diamond.scisoft.analysis.test/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianSqrTest.java
+++ b/uk.ac.diamond.scisoft.analysis.test/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianSqrTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2015 Gero Flucke, DESY.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package uk.ac.diamond.scisoft.analysis.fitting.functions;
+
+import org.eclipse.dawnsci.analysis.api.fitting.functions.IFunction;
+import org.eclipse.dawnsci.analysis.dataset.impl.Dataset;
+import org.eclipse.dawnsci.analysis.dataset.impl.DatasetUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LorentzianSqrTest {
+
+	private static final double ABS_TOL = 1e-7;
+
+	@Test
+	public void testFunction() 
+	{
+ 		this.testLorentzianSqr(23., 2., 1.5); // as Lorentzian
+		this.testLorentzianSqr(1, 0.1, 10.); // area >> fwhm
+		this.testLorentzianSqr(999., .9, 1.1);// area ~ fwhm
+		this.testLorentzianSqr(-10., 10., 0.1);// area << fwhm
+	}
+	public void testLorentzianSqr(double pos, double fwhm, double area)
+	{
+		IFunction f = new LorentzianSqr();
+		// test number of parameters and whether parameters are correctly stored
+		Assert.assertEquals(3, f.getNoOfParameters());
+		f.setParameterValues(pos, fwhm, area);
+		Assert.assertArrayEquals(new double[] {pos, fwhm, area}, f.getParameterValues(), ABS_TOL);
+
+		// test function values at centre and centre +/1 0.5*fwhm
+		double widthPar = fwhm / Math.sqrt(Math.sqrt(2.) - 1.);	
+		double height = area / (0.25 * Math.PI * widthPar);
+		Assert.assertEquals(height, f.val(pos), ABS_TOL);
+		Assert.assertEquals(0.5 * height, f.val(pos - 0.5 * fwhm), ABS_TOL);
+		Assert.assertEquals(0.5 * height, f.val(pos + 0.5 * fwhm), ABS_TOL);
+
+		// test that equals(f2) works even if f2 is still "dirty" 
+		LorentzianSqr f2 = new LorentzianSqr(new double[] {pos, fwhm, area});
+		Assert.assertTrue(f.equals(f2));
+		
+		// integral from -inf to inf should be area,
+		// actual range related to fwhm, bin width as well
+		int nBins = (int) Math.ceil(1402./fwhm);
+		if ((nBins % 2) == 0) {
+			nBins += 1; // odd number of bins to get peak
+		}
+		Dataset x = DatasetUtils.linSpace(-50.*fwhm+pos, 50.*fwhm+pos, nBins, Dataset.FLOAT64);
+		Dataset v = DatasetUtils.convertToDataset(f2.calculateValues(x));
+		double s = ((Number) v.sum()).doubleValue() * Math.abs(x.getDouble(0) - x.getDouble(1));
+		Assert.assertEquals(area, s, 1e-2); // relaxed tolerance: poor man's integration only...
+		// test that calculateValues(dataset) gives same as f.val(double)
+		Assert.assertEquals(v.getDouble(0), f.val(x.getDouble(0)), ABS_TOL);
+		
+	}
+}

--- a/uk.ac.diamond.scisoft.analysis.test/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianTest.java
+++ b/uk.ac.diamond.scisoft.analysis.test/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianTest.java
@@ -32,9 +32,16 @@ public class LorentzianTest {
 		Assert.assertEquals(0.5 * h, f.val(23. - 1), ABS_TOL);
 		Assert.assertEquals(0.5 * h, f.val(23. + 1), ABS_TOL);
 
+		// test that equals(f2) works even if f2 is still "dirty" 
+		IFunction f2 = new Lorentzian(new double[] {23., 2., 1.2});
+		Assert.assertTrue(f.equals(f2));
+		
 		Dataset x = DatasetUtils.linSpace(-100+23, 100+23, 201, Dataset.FLOAT64);
 		Dataset v = DatasetUtils.convertToDataset(f.calculateValues(x));
 		double s = ((Number) v.sum()).doubleValue() * Math.abs(x.getDouble(0) - x.getDouble(1));
 		Assert.assertEquals(1.2, s, 1e-2);
+
+		// test that calculateValues(dataset) gives same as f.val(double)
+		Assert.assertEquals(v.getDouble(0), f.val(x.getDouble(0)), ABS_TOL);
 	}
 }

--- a/uk.ac.diamond.scisoft.analysis/src/uk/ac/diamond/scisoft/analysis/fitting/functions/Lorentzian.java
+++ b/uk.ac.diamond.scisoft.analysis/src/uk/ac/diamond/scisoft/analysis/fitting/functions/Lorentzian.java
@@ -167,6 +167,8 @@ public class Lorentzian extends APeak {
 
 	@Override
 	public int hashCode() {
+		if (isDirty())
+			calcCachedParameters();
 		final int prime = 31;
 		int result = super.hashCode();
 		long temp;
@@ -181,11 +183,14 @@ public class Lorentzian extends APeak {
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (!super.equals(obj))
-			return false;
 		if (getClass() != obj.getClass())
 			return false;
 		Lorentzian other = (Lorentzian) obj;
+		if (this. isDirty()) this. calcCachedParameters();
+		if (other.isDirty()) other.calcCachedParameters();
+		// call to super.equals(..) after calcCachedParameters(..): it tests dirty 
+		if (!super.equals(obj))
+			return false;
 		if (Double.doubleToLongBits(halfw) != Double.doubleToLongBits(other.halfw))
 			return false;
 		if (Double.doubleToLongBits(pos) != Double.doubleToLongBits(other.pos))

--- a/uk.ac.diamond.scisoft.analysis/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianSqr.java
+++ b/uk.ac.diamond.scisoft.analysis/src/uk/ac/diamond/scisoft/analysis/fitting/functions/LorentzianSqr.java
@@ -121,15 +121,15 @@ public class LorentzianSqr extends APeak {
 		}
 	}
 
-	double widthPar, pos;
+	double halfWidthPar, pos; // 'height' already declared in APeak
 
 	// conversion between FWHM and parameter G in function:
-	private static final double CONST = 1./Math.sqrt(Math.sqrt(2.0) - 1.);
+	private static final double CONST = 0.5/Math.sqrt(Math.sqrt(2.0) - 1.);
 	@Override
 	protected void calcCachedParameters() {
 		pos = getParameterValue(POSN);
-		widthPar = getParameterValue(FWHM) * CONST;
-		height = getParameterValue(AREA) / (0.5 * Math.PI * widthPar);
+		halfWidthPar = getParameterValue(FWHM) * CONST;
+		height = getParameterValue(AREA) / (0.5 * Math.PI * halfWidthPar);
 
 		setDirty(false);
 	}
@@ -139,7 +139,7 @@ public class LorentzianSqr extends APeak {
 		if (isDirty())
 			calcCachedParameters();
 
-		double dist = (values[0] - pos) / widthPar;
+		double dist = (values[0] - pos) / halfWidthPar;
 		double denominatorSqrt = (dist * dist + 1);
 		return height / (denominatorSqrt * denominatorSqrt);
 	}
@@ -154,34 +154,20 @@ public class LorentzianSqr extends APeak {
 		int i = 0;
 		double[] buffer = data.getData();
 		while (it.hasNext()) {
-			double dist = (coords[0] - pos) / widthPar; 
+			double dist = (coords[0] - pos) / halfWidthPar; 
 			double denominatorSqrt = (dist * dist + 1);
 			buffer[i++] = height / (denominatorSqrt * denominatorSqrt);
 		}
 	}
 
-//	public double getHalfw() {
-//		return halfw;
-//	}
-//
-//	public void setHalfw(double halfw) {
-//		this.halfw = halfw;
-//	}
-
-	public double getPos() {
-		return pos;
-	}
-
-	public void setPos(double pos) {
-		this.pos = pos;
-	}
-
 	@Override
 	public int hashCode() {
+		if (isDirty())
+			calcCachedParameters();
 		final int prime = 31;
 		int result = super.hashCode();
 		long temp;
-		temp = Double.doubleToLongBits(widthPar);
+		temp = Double.doubleToLongBits(halfWidthPar);
 		result = prime * result + (int) (temp ^ (temp >>> 32));
 		temp = Double.doubleToLongBits(pos);
 		result = prime * result + (int) (temp ^ (temp >>> 32));
@@ -192,13 +178,15 @@ public class LorentzianSqr extends APeak {
 	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
-		if (!super.equals(obj))
-			return false;
 		if (getClass() != obj.getClass())
 			return false;
 		LorentzianSqr other = (LorentzianSqr) obj;
-		// other data members tested already in super.equals(..)
-		if (Double.doubleToLongBits(widthPar) != Double.doubleToLongBits(other.widthPar))
+		if (this .isDirty()) this .calcCachedParameters();
+		if (other.isDirty()) other.calcCachedParameters();
+		// call to super.equals(..) after calcCachedParameters(..): it tests dirty 
+		if (!super.equals(obj))
+			return false;
+		if (Double.doubleToLongBits(halfWidthPar) != Double.doubleToLongBits(other.halfWidthPar))
 			return false;
 		if (Double.doubleToLongBits(pos) != Double.doubleToLongBits(other.pos))
 			return false;


### PR DESCRIPTION
Details:
- add unit test for new function LorentzianSqr
- fix function to pass it :-|
- extend unit test for Lorentzian
- make Lorentzian pass its extended test
Actually, looking at the code of other functions like, e.g. Gaussian, their equals(..) and hashCode() methods suffer from the same bug as the Lorentzian. In addition, APeak should implement equals(..) and test for equality of its 'height' member. Probably 'height' should also be taken into account in hashCode().
Since I am lazy I leave it to the core team to fix that....